### PR TITLE
Python 3 selection

### DIFF
--- a/bin/index-pgn.py
+++ b/bin/index-pgn.py
@@ -1,11 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import requests
 import sys
 import time
 
-if len(sys.argv) != 3:
-    sys.exit("Usage: python3 index-pgn.py <master|lichess/standard|...> <pgn-file>")
+if sys.version_info[0] < 3:
+    sys.exit("Minimum requirement is Python 3.3.")
+elif sys.version_info[0] == 3 and sys.version_info[1] <= 2:
+    sys.exit("Minimum requirement is Python 3.3.")
+elif sys.version_info[0] == 3 and sys.version_info[1] >= 3:
+    pass
+elif sys.version_info[0] >= 4:
+    pass
+else:
+    sys.exit("Oh dear, you appear to have broken reality ... how did you manage that anyway?")
+
+if len(sys.argv) <= 2:
+    sys.exit("Usage: index-pgn.py <master|lichess/standard|...> <pgn-file>")
 
 endpoint = sys.argv[1]
 


### PR DESCRIPTION
* At this stage it is more than reasonable to select Python 3 and no
  longer support Python 2.7 (especially with that usage exit message),
  not to mention 2.7 hitting EOL in 2020 (just like Roy Batty, it will
  be gone ... like tears in rain ...).
* Included a check to stick with 3.3 or above.  It'd probably work
  with 3.2, but the major changes, IIRC, were relating to Unicode
  handling and given some of the bad encoding in some of the PGN files
  floating around anything that prevents trying to troubleshoot
  character encoding clashes is a Good Thing™.
* I'm pretty sure it should be mathematically impossible to hit the
  final "else" part of that check.
* The script is too simple to give it argparse flags, but that can
  always be misappropriated from one of my dodgier projects (dodgy by
  content, not code quality).